### PR TITLE
[INSTANCE] history.state now records router instance id

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,9 +2,15 @@
 
 Tiny Express-inspired client-side router.
 
- [![Build Status](https://travis-ci.org/visionmedia/page.js.svg?branch=master)](https://travis-ci.org/visionmedia/page.js)
-[![Coverage Status](https://coveralls.io/repos/visionmedia/page.js/badge.svg?branch=master)](https://coveralls.io/r/visionmedia/page.js?branch=master)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/visionmedia/page.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+# What's different between my version and the original version:
+
+- Added option for a routerId to disinguish between multiple apps that all use different instances of `page`
+
+```js
+page({ routerId: "YOUR_APP_NAME" });
+```
+
+# --- ORIGINAL README BELOW ---
 
 ```js
 page('/', index)

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "page",
+  "version": "2.0.0",
   "description": "Tiny client-side router",
   "keywords": ["page", "route", "router", "routes", "pushState"],
   "main": "page.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "page",
   "description": "Tiny client-side router",
-  "version": "1.8.6",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/page.js
+++ b/page.js
@@ -592,6 +592,9 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     options = options || {};
     if (running) return;
     running = true;
+
+    page.id = options.routerId || "GLOBAL_PAGE_ROUTER";
+
     pageWindow = options.window || (hasWindow && window);
     if (false === options.dispatch) dispatch = false;
     if (false === options.decodeURLComponents) decodeURLComponents = false;
@@ -844,10 +847,11 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this.title = (hasDocument && pageWindow.document.title);
     this.state = state || {};
     this.state.path = path;
+    this.state.router = page.id;
     this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
     this.pathname = decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);
     this.params = {};
-
+    
     // fragment
     this.hash = '';
     if (!hashbang) {
@@ -989,10 +993,15 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       });
     }
     return function onpopstate(e) {
+      debugger;
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;
-        page.replace(path, e.state);
+        if (e.state.router === page.id) {
+          page.replace(path, e.state);
+        } else {
+          pageWindow.location = path;
+        }
       } else if (isLocation) {
         var loc = pageWindow.location;
         page.show(loc.pathname + loc.hash, undefined, undefined, false);

--- a/page.js
+++ b/page.js
@@ -993,7 +993,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       });
     }
     return function onpopstate(e) {
-      debugger;
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;


### PR DESCRIPTION
From experience, when an application has multiple instances of page mounted to the same domain, the back/forward buttons don't work between apps. This is because the `popstate`event handler assumes that it is the only other router using the history API. This is not helpful in my case mentioned. For this reason, I added option for a routerId to disinguish between multiple apps that all use different instances of `page`. Each instance now states its name when starting up.

```js
page({ routerId: "YOUR_APP_NAME" });
```